### PR TITLE
Support concurrent application instances/checks

### DIFF
--- a/lib/heartcheck/cache.rb
+++ b/lib/heartcheck/cache.rb
@@ -1,2 +1,3 @@
+require 'securerandom'
 require 'heartcheck'
 require 'heartcheck/checks/cache'

--- a/lib/heartcheck/checks/cache.rb
+++ b/lib/heartcheck/checks/cache.rb
@@ -24,7 +24,7 @@ module Heartcheck
       #
       # @return [Bollean]
       def set?(con)
-        con.set('check_test', 'heartcheck')
+        con.set(unique_check_key, 'heartcheck')
       rescue
         false
       end
@@ -35,7 +35,7 @@ module Heartcheck
       #
       # @return [Bollean]
       def get?(con)
-        con.get('check_test') == 'heartcheck'
+        con.get(unique_check_key) == 'heartcheck'
       rescue
         false
       end
@@ -46,7 +46,7 @@ module Heartcheck
       #
       # @return [Bollean]
       def delete?(con)
-        con.delete('check_test')
+        con.delete(unique_check_key)
       rescue
         false
       end
@@ -60,6 +60,15 @@ module Heartcheck
       # @return [void]
       def custom_error(name, key_error)
         @errors << "#{name} fails to #{key_error}"
+      end
+
+      # generate an unique redis key
+      # It's necessary to run concurrent application instances/checks using a
+      # shared memcache
+      #
+      # @return [String]
+      def unique_check_key
+        @unique_check_key ||= SecureRandom.hex
       end
     end
   end

--- a/spec/heartcheck/checks/cache_spec.rb
+++ b/spec/heartcheck/checks/cache_spec.rb
@@ -62,5 +62,23 @@ RSpec.describe Heartcheck::Checks::Cache do
         end
       end
     end
+
+    it 'supports concurrent application instances/checks' do
+      total_concurrent_instances = 30
+
+      concurrent_checks = 0.upto(total_concurrent_instances).map do |n|
+        Thread.new do
+          checker_instance = described_class.new.tap do |c|
+            c.add_service(name: "check #{n}", connection: connection)
+          end
+
+          checker_instance.check
+        end
+      end
+
+      check_results = concurrent_checks.map(&:value)
+
+      expect(check_results.inspect).not_to include('error')
+    end
   end
 end


### PR DESCRIPTION
# Motivation

Generally, we have many instances of the same application (for load balancing) and sometimes different applications sharing a single Memcache data source.

In these scenarios, the checks randomly fail, depending on the order of `get`,` set`, `delete` competing between all instances.

# Proposal

Use unique keys when accessing Memcache.