### PR TITLE
Added Github WorkFlow to Repo

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.3', '2.4', '2.5', '2.6', '2.7']
+        ruby-version: ['2.5', '2.6', '2.7']
 
     steps:
     - uses: actions/checkout@v2 

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -31,6 +31,8 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+    - name: Setup
+      run: bundle install -j 4 --retry 3
     - name: Memcached Service
       # You may pin to the exact commit or the version.
       # uses: niden/actions-memcached@3b3ecd9d0d035ea92db716dc1540a7dbe9e56349

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,0 +1,41 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
+# For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
+
+name: Ruby
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version: ['2.3', '2.4', '2.5', '2.6', '2.7']
+
+    steps:
+    - uses: actions/checkout@v2 
+    - name: Set up Ruby
+    # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
+    # change this to (see https://github.com/ruby/setup-ruby#versioning):
+    # uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@473e4d8fe5dd94ee328fdfca9f8c9c7afc9dae5e
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+    - name: Memcached Service
+      # You may pin to the exact commit or the version.
+      # uses: niden/actions-memcached@3b3ecd9d0d035ea92db716dc1540a7dbe9e56349
+      uses: niden/actions-memcached@v7
+    - name: Install
+      run: bundle install -j 4 --retry 3
+    - name: Run tests
+      run: test bundle exec rspec spec

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -36,4 +36,4 @@ jobs:
       # uses: niden/actions-memcached@3b3ecd9d0d035ea92db716dc1540a7dbe9e56349
       uses: niden/actions-memcached@v7
     - name: Run tests
-      run: RAILS_ENV=test bundle exec rspec spec
+      run: bundle exec rspec

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -35,7 +35,5 @@ jobs:
       # You may pin to the exact commit or the version.
       # uses: niden/actions-memcached@3b3ecd9d0d035ea92db716dc1540a7dbe9e56349
       uses: niden/actions-memcached@v7
-    - name: Install
-      run: bundle install -j 4 --retry 3
     - name: Run tests
-      run: test bundle exec rspec spec
+      run: RAILS_ENV=test bundle exec rspec spec

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -9,9 +9,9 @@ name: Ruby
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, dev-github-actions ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, dev-github-actions ]
 
 jobs:
   test:


### PR DESCRIPTION
Hey, I have added the github workflow to setup ruby and memcached but I had to remove 2 versions 2.3,2.4 as it was throwing an error saying 
```
bundler: failed to load command: rspec (/home/sumera/.rbenv/versions/2.5.1/bin/rspec)
...: command not found
```

After searching I came across a similar issue [here] (https://github.com/SciRuby/daru/issues/503).

I have tried fixing issue #9  but do check it once @VictorSNA 